### PR TITLE
Typo in Usage

### DIFF
--- a/nxpt
+++ b/nxpt
@@ -492,7 +492,7 @@ else
 
 	\trestore						Restore the device back to factory status (4.4.4 default)
 
-	\trboot	  					Reboot all connected tablets
+	\treboot	  					Reboot all connected tablets
 
 	\tconfigure-wifi <ssid> <password>		Add a network, (currently defaults to WPA/WPA2 PSK)
 


### PR DESCRIPTION
it said nxpt rboot would reboot when it should read reboot.
